### PR TITLE
fix: Yadng will stop existing DnD events

### DIFF
--- a/yadng.js
+++ b/yadng.js
@@ -50,9 +50,6 @@ var _dragover = function(e) {
 };
 
 var _drop = function(e) {
-	if (e.stopPropagation) {
-		e.stopPropagation();
-	}
 	if (_yadng.selection) {
 		_yadng.endX = e.x;
 		_yadng.endY = e.y;


### PR DESCRIPTION
Fixed when the website already has DnD events and the visitor is using Yadng, Yadng will stop the existing DnD events from being triggered.